### PR TITLE
Add pipeline skeleton and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,30 @@ Use it for:
 - DevRel content
 - Internal onboarding
 - Just plain fun
+
+## Example: IAM-POSSIBLE
+
+The `projects/iam-possible` folder shows a complete run of the pipeline. It
+presents AWS Identity and Access Management as a Tarantino-style nightclub
+heist narrated by a cocky hacker with Samuel L. Jackson flair. Running this
+project generates a script, storyboard, and timing matrix, then renders a final
+voiceover and video using services like ElevenLabs and Sora. All produced
+assets are uploaded to a rate-limited S3 bucket.
+
+## Pipeline Overview
+
+1. **Define your project** in a YAML file (see `projects/iam-possible/PROMPT_INPUTS.yaml`).
+2. **Run the pipeline**:
+
+   ```bash
+   python -m cli.build_project path/to/PROMPT_INPUTS.yaml
+   ```
+3. `scene_builder` uses an LLM to draft each scene's narration.
+4. `storyboard_gen` converts narration into visual prompts.
+5. `timing_chain` estimates how long each line will take.
+6. `narrator_voice_gen` calls ElevenLabs to create an audio track.
+7. `replicate_api` (or Sora) renders the final video using the storyboard and audio.
+8. `s3_deployer` uploads the assets so they can be downloaded or shared.
+
+This repository contains lightweight stubs for each step so you can see how the
+pieces fit together before plugging in real API keys and logic.

--- a/cli/build_project.py
+++ b/cli/build_project.py
@@ -1,1 +1,48 @@
-# CLI runner that wires together chains to build full output
+"""CLI entry point for running a project through the pipeline."""
+
+import argparse
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    yaml = None
+
+from core.chains.scene_builder import generate_script
+from core.chains.storyboard_gen import generate_storyboard
+from core.chains.timing_chain import estimate_timing
+from core.chains.narrator_voice_gen import build_voiceover
+from core.services.replicate_api import render_video
+from core.services.s3_deployer import deploy
+
+
+def build_project(config_path: str) -> None:
+    """Run the full pipeline using the given YAML configuration."""
+
+    if yaml is None:
+        raise RuntimeError("pyyaml is required to load project files")
+
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    script = generate_script(config)
+    storyboard = generate_storyboard(script)
+    timings = estimate_timing(script)
+    voice_path = build_voiceover(script, config)
+    video_path = render_video(storyboard, voice_path, config)
+
+    deploy(voice_path, config)
+    deploy(video_path, config)
+
+    print("Pipeline complete. Artifacts generated in", config.get("output_dir", "output"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run prompt2production pipeline")
+    parser.add_argument("config", help="Path to project YAML configuration")
+    args = parser.parse_args()
+
+    build_project(args.config)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/core/chains/narrator_voice_gen.py
+++ b/core/chains/narrator_voice_gen.py
@@ -1,1 +1,13 @@
-# Formats and routes narrator voice prompts to ElevenLabs API
+"""Narrator voice generation chain."""
+
+from typing import List
+
+from core.services.elevenlabs_api import synthesize_voice
+
+
+def build_voiceover(script: List[str], config: dict) -> str:
+    """Generate a voiceover file using the ElevenLabs service."""
+
+    text = "\n".join(script)
+    return synthesize_voice(text, config)
+

--- a/core/chains/scene_builder.py
+++ b/core/chains/scene_builder.py
@@ -1,1 +1,24 @@
-# Generates scene-by-scene voiceover lines using LLM prompts
+"""Scene builder chain.
+
+This module would normally call an LLM like Amazon Bedrock to expand the
+project configuration into a full script. To keep the repository lightweight,
+`generate_script` simply creates placeholder lines so the rest of the pipeline
+can be demonstrated without external services.
+"""
+
+from typing import List, Dict
+
+
+def generate_script(config: Dict) -> List[str]:
+    """Return a dummy script for the requested scene count."""
+
+    scene_count = int(config.get("scene_count", 3))
+    project_name = config.get("project_name", "demo")
+
+    script = [
+        f"Scene {i + 1}: Placeholder narration for {project_name}."
+        for i in range(scene_count)
+    ]
+
+    return script
+

--- a/core/chains/storyboard_gen.py
+++ b/core/chains/storyboard_gen.py
@@ -1,1 +1,10 @@
-# Generates visual prompt descriptions per scene
+"""Storyboard generation chain."""
+
+from typing import List
+
+
+def generate_storyboard(script: List[str]) -> List[str]:
+    """Create a simple visual description for each line of script."""
+
+    return [f"Visual: {line}" for line in script]
+

--- a/core/chains/timing_chain.py
+++ b/core/chains/timing_chain.py
@@ -1,1 +1,15 @@
-# Estimates scene timing based on token length or audio duration
+"""Timing estimation chain."""
+
+from typing import List, Dict
+
+
+def estimate_timing(script: List[str]) -> List[Dict[str, float]]:
+    """Return a simple timing matrix assuming ~2 words per second."""
+
+    timings = []
+    for line in script:
+        seconds = max(1, len(line.split()) / 2)
+        timings.append({"line": line, "seconds": seconds})
+
+    return timings
+

--- a/core/services/bedrock_nova.py
+++ b/core/services/bedrock_nova.py
@@ -1,1 +1,8 @@
-# Wrapper to call Amazon Bedrock (Claude/Nova) for LLM tasks
+"""Tiny wrapper around a hypothetical Bedrock/Nova LLM API."""
+
+
+def run_prompt(prompt: str) -> str:
+    """Return a fake LLM result."""
+
+    return f"[LLM output for: {prompt[:30]}...]"
+

--- a/core/services/elevenlabs_api.py
+++ b/core/services/elevenlabs_api.py
@@ -1,1 +1,14 @@
-# Handles ElevenLabs voice generation and playback
+"""Simple ElevenLabs wrapper."""
+
+from pathlib import Path
+
+
+def synthesize_voice(text: str, config: dict) -> str:
+    """Pretend to create an MP3 file with ElevenLabs."""
+
+    out_dir = Path(config.get("output_dir", "output"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / "voiceover.mp3"
+    out_file.write_text("synthetic audio")
+    return str(out_file)
+

--- a/core/services/replicate_api.py
+++ b/core/services/replicate_api.py
@@ -1,1 +1,14 @@
-# Handles calls to Replicate video generation endpoints
+"""Video generation wrapper."""
+
+from pathlib import Path
+
+
+def render_video(storyboard: list, voice_path: str, config: dict) -> str:
+    """Write a placeholder video file."""
+
+    out_dir = Path(config.get("output_dir", "output"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    video_file = out_dir / "video.mp4"
+    video_file.write_text("synthetic video")
+    return str(video_file)
+

--- a/core/services/s3_deployer.py
+++ b/core/services/s3_deployer.py
@@ -1,1 +1,9 @@
-# Deploys finished artifacts to S3 with rate limiting or TTL config
+"""Deployment helper for uploading assets to S3."""
+
+
+def deploy(path: str, config: dict) -> None:
+    """Pretend to deploy an artifact to S3."""
+
+    bucket = config.get("deployment", {}).get("s3_bucket", "demo")
+    print(f"Uploading {path} to s3://{bucket}/")
+

--- a/core/utils/tokenizer.py
+++ b/core/utils/tokenizer.py
@@ -1,1 +1,8 @@
-# Utility to count tokens or estimate speech time for narration
+"""Utility helpers for tokenization."""
+
+
+def count_tokens(text: str) -> int:
+    """Return a naive token count."""
+
+    return len(text.split())
+


### PR DESCRIPTION
## Summary
- lay out an eight-step pipeline in the README
- implement stub pipeline functions for chains and services
- add a CLI that wires the pieces together

## Testing
- `pytest -q`
- `pip install pyyaml` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68465279fbb8832abf69d23d00842ca2