### PR TITLE
Implement full workflow with docs

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -1,0 +1,142 @@
+# EXPLAINER.md – How `prompt2production` Works
+
+This document provides a comprehensive walkthrough of how the `prompt2production` framework operates. It describes the purpose, architecture, components, and the step-by-step workflow used to generate fully-formed cinematic explainers from simple YAML inputs.
+
+---
+
+## 🧐 Purpose
+
+`prompt2production` is a modular AI-powered pipeline that transforms a **technical topic** and a **creative metaphor** into a complete set of production-ready media artifacts. Think: explainer videos styled like Tarantino films or Pixar shorts—educational, entertaining, and visually arresting.
+
+It’s designed for developers, DevRel professionals, security educators, and AI creatives who want to tell powerful technical stories through stylized multimedia.
+
+---
+
+## 🧑‍🏫 Architecture
+
+PROMPT_INPUTS.yaml
+↓
+SceneBuilder (LLM)
+↓
+Voiceover Script (SCRIPT.md)
+↓
+Storyboard Prompt Generator (LLM)
+↓
+Visual Prompts (STORYBOARD.md)
+↓
+Timing Estimator
+↓
+Timed Script (TIMED_SCRIPT.md)
+↓
+Optional Rendering (via APIs)
+↓
+Packaged Output
+↓
+S3 Deployment (with request limiter)
+
+---
+
+## 🗂 Directory Breakdown
+
+- `core/`: Shared logic across all projects
+  - `chains/`: Prompt chains for script, storyboard, voice, timing
+  - `templates/`: Jinja2 templates for prompts
+  - `services/`: API wrappers for LLMs, voice, and video
+  - `utils/`: Helpers like token counters
+- `projects/`: Project-specific content (e.g. IAM-POSSIBLE)
+- `output/`: Generated assets
+- `cli/`: Entry point for automated chains
+- `Makefile`: Build automation
+
+---
+
+## 🤐 Workflow Explained
+
+### 1. Author `PROMPT_INPUTS.yaml`
+This file contains the blueprint for your video:
+
+```yaml
+technical_topic: "AWS IAM"
+metaphor_world: "Nightclub security"
+narrator_style: "Samuel L. Jackson"
+scene_count: 18
+tone: "Cocky, cinematic, accurate"
+voice_model: "ElevenLabs"
+video_model: "Sora"
+```
+
+### 2. Run the Project Build
+```bash
+make build PROJECT=iam-possible
+```
+This launches the following chain of events:
+
+### 3. SceneBuilder Chain (`scene_builder.py`)
+Splits the story into `scene_count` sections
+Prompts the LLM (via Bedrock Nova or Claude) to write a line of VO per scene
+Output → `SCRIPT.md`
+Template: `vo_prompt.jinja`
+
+### 4. Storyboard Generator (`storyboard_gen.py`)
+Converts each scene’s VO line into a vivid visual description
+Uses metaphor context + narrator tone + scene number
+Output → `STORYBOARD.md`
+Template: `visual_prompt.jinja`
+
+### 5. Timing Estimator (`timing_chain.py`)
+Tokenizes each VO line
+Estimates playback time using either:
+- ElevenLabs preview API
+- Static WPM model (default)
+Output → `TIMED_SCRIPT.md`
+
+### 6. Narrator Voice Rendering (optional)
+Uses ElevenLabs to synthesize each VO line
+Respects narrator profile (e.g., energy, accent, pacing)
+Output → `final_voiceover.mp3`
+
+### 7. Cinematic Video Generation (optional)
+Uses Sora or Replicate’s video API
+Inputs from `STORYBOARD.md`
+Output → `final_video.mp4`
+
+### 8. Assemble Output
+Stored in `/output/final/`:
+- `final_video.mp4`
+- `final_voiceover.mp3`
+- `SCRIPT.md`
+- `STORYBOARD.md`
+- `TIMED_SCRIPT.md`
+- `transcript.txt`
+- `render_notes.md`
+
+### 9. Deploy to S3
+`s3_deployer.py` uploads all assets to the defined bucket
+A CloudFront layer or TTL rule can limit access after 1,000 requests
+Enables public viewing without abuse risk
+
+---
+
+### 🔐 External Dependencies
+- Amazon Bedrock (Nova or Claude) – for scene/VO generation
+- ElevenLabs – for narrator voice synthesis
+- Sora (OpenAI) or Replicate – for cinematic visuals
+
+### 🗜‍🏰 Use Cases
+- Developer onboarding videos
+- DevSecOps training (e.g., IAM-POSSIBLE)
+- DevRel content
+- Story-driven walkthroughs of APIs
+- Satirical tech education (e.g., TCP/IP noir detective)
+
+### 🛠 Planned Features
+- Web UI for creating new projects visually
+- Prebuilt narrator voice profiles
+- LangChain or Strands backend for more complex flows
+- Version-controlled runs per project
+
+### ✅ Summary
+With prompt2production, a YAML input becomes an entire cinematic training artifact—voiced, visualized, and packaged for delivery. Each module is swappable, making it ideal for future expansion.
+
+Build once. Reuse forever. Tell better tech stories.
+

--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,6 @@
 # Makefile to simplify build commands like `make build PROJECT=...`
+
+PROJECT ?= iam-possible
+
+build:
+	python -m cli.build_project projects/$(PROJECT)/PROMPT_INPUTS.yaml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 **prompt2production** is a generative media pipeline for turning technical topics into cinematic, metaphor-driven explainers.
 
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
 It uses:
 - LLMs for scripting (via Bedrock/Nova)
 - Voice cloning APIs (like ElevenLabs)
@@ -16,3 +22,46 @@ Use it for:
 - DevRel content
 - Internal onboarding
 - Just plain fun
+
+## Example: IAM-POSSIBLE
+
+The `projects/iam-possible` folder shows a complete run of the pipeline. It
+presents AWS Identity and Access Management as a Tarantino-style nightclub
+heist narrated by a cocky hacker with Samuel L. Jackson flair. Running this
+project generates a script, storyboard, and timing matrix, then renders a final
+voiceover and video using services like ElevenLabs and Sora. All produced
+assets are uploaded to a rate-limited S3 bucket.
+
+## Pipeline Overview
+
+See [EXPLAINER.md](EXPLAINER.md) for a full walkthrough of how the pipeline works.
+
+1. **Define your project** in a YAML file (see `projects/iam-possible/PROMPT_INPUTS.yaml`).
+2. **Run the pipeline**:
+
+   ```bash
+   make build PROJECT=iam-possible
+   ```
+3. `scene_builder` uses an LLM to draft each scene's narration.
+4. `storyboard_gen` converts narration into visual prompts.
+5. `timing_chain` estimates how long each line will take.
+6. `narrator_voice_gen` calls ElevenLabs to create an audio track.
+7. `replicate_api` (or Sora) renders the final video using the storyboard and audio.
+8. `s3_deployer` uploads the assets so they can be downloaded or shared.
+
+This repository contains lightweight stubs for each step so you can see how the
+pieces fit together before plugging in real API keys and logic.
+
+## Configuration
+
+The pipeline expects a few environment variables so it can connect to external
+services:
+
+- ``ELEVENLABS_API_KEY`` – used for voice synthesis.
+- ``REPLICATE_API_TOKEN`` – required for video generation with Replicate.
+
+By default the video step calls the ``minimax/video-01`` model on Replicate. If
+the ``replicate`` package is not installed or the API call fails, a placeholder
+file is created so you can test the rest of the pipeline offline. Text-to-text
+prompts use AWS Bedrock's Nova model, which reads credentials from your
+``~/.aws/credentials`` file.

--- a/cli/build_project.py
+++ b/cli/build_project.py
@@ -1,1 +1,64 @@
-# CLI runner that wires together chains to build full output
+"""CLI entry point for running a project through the pipeline."""
+
+import argparse
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    yaml = None
+
+from pathlib import Path
+
+from core.chains.scene_builder import generate_script
+from core.chains.storyboard_gen import generate_storyboard
+from core.chains.timing_chain import estimate_timing
+from core.chains.narrator_voice_gen import build_voiceover
+from core.services.replicate_api import render_video
+from core.services.s3_deployer import deploy
+
+
+def build_project(config_path: str) -> None:
+    """Run the full pipeline using the given YAML configuration."""
+
+    if yaml is None:
+        raise RuntimeError("pyyaml is required to load project files")
+
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    output_dir = Path(config.get("output_dir", "output"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    script = generate_script(config)
+    storyboard = generate_storyboard(script, config)
+    timings = estimate_timing(script, config.get("words_per_minute", 120))
+
+    (output_dir / "SCRIPT.md").write_text("\n".join(script))
+    (output_dir / "STORYBOARD.md").write_text("\n".join(storyboard))
+    timing_lines = [f"{t['seconds']:.2f}s: {t['line']}" for t in timings]
+    (output_dir / "TIMED_SCRIPT.md").write_text("\n".join(timing_lines))
+
+    voice_path = build_voiceover(script, config)
+    video_path = render_video(storyboard, voice_path, config)
+
+    (output_dir / "transcript.txt").write_text("\n".join(script))
+    (output_dir / "render_notes.md").write_text(
+        f"Video model: {config.get('video_model', 'unknown')}\n"
+    )
+
+    deploy(voice_path, config)
+    deploy(video_path, config)
+
+    print("Pipeline complete. Artifacts generated in", output_dir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run prompt2production pipeline")
+    parser.add_argument("config", help="Path to project YAML configuration")
+    args = parser.parse_args()
+
+    build_project(args.config)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/core/chains/narrator_voice_gen.py
+++ b/core/chains/narrator_voice_gen.py
@@ -1,1 +1,13 @@
-# Formats and routes narrator voice prompts to ElevenLabs API
+"""Narrator voice generation chain."""
+
+from typing import List
+
+from core.services.elevenlabs_api import synthesize_voice
+
+
+def build_voiceover(script: List[str], config: dict) -> str:
+    """Generate a voiceover file using the ElevenLabs service."""
+
+    text = "\n".join(script)
+    return synthesize_voice(text, config)
+

--- a/core/chains/scene_builder.py
+++ b/core/chains/scene_builder.py
@@ -1,1 +1,40 @@
-# Generates scene-by-scene voiceover lines using LLM prompts
+"""Scene builder chain.
+
+This module would normally call an LLM like Amazon Bedrock to expand the
+project configuration into a full script. To keep the repository lightweight,
+`generate_script` simply creates placeholder lines so the rest of the pipeline
+can be demonstrated without external services.
+"""
+
+from typing import List, Dict
+from pathlib import Path
+
+from jinja2 import Template
+
+from core.services.bedrock_nova import run_prompt
+
+
+def generate_script(config: Dict) -> List[str]:
+    """Return a dummy script for the requested scene count."""
+
+    scene_count = int(config.get("scene_count", 3))
+
+    template_path = Path(__file__).resolve().parent.parent / "templates" / "vo_prompt.jinja"
+    template = Template(template_path.read_text())
+
+    context = {
+        "technical_topic": config.get("technical_topic", "demo"),
+        "metaphor_world": config.get("metaphor_world", "demo"),
+        "narrator_style": config.get("narrator_style", "plain"),
+        "tone": config.get("tone", "neutral"),
+        "scene_count": scene_count,
+    }
+
+    script = []
+    for i in range(scene_count):
+        context["index"] = i + 1
+        prompt = template.render(**context)
+        script.append(run_prompt(prompt))
+
+    return script
+

--- a/core/chains/storyboard_gen.py
+++ b/core/chains/storyboard_gen.py
@@ -1,1 +1,28 @@
-# Generates visual prompt descriptions per scene
+"""Storyboard generation chain."""
+
+from typing import List, Dict
+from pathlib import Path
+
+from jinja2 import Template
+
+from core.services.bedrock_nova import run_prompt
+
+
+def generate_storyboard(script: List[str], config: Dict) -> List[str]:
+    """Generate visual prompts for each line using Bedrock/Nova."""
+
+    template_path = Path(__file__).resolve().parent.parent / "templates" / "visual_prompt.jinja"
+    template = Template(template_path.read_text())
+
+    prompts = []
+    ctx = {
+        "metaphor_world": config.get("metaphor_world", "demo"),
+        "tone": config.get("tone", "neutral"),
+    }
+    for idx, line in enumerate(script, start=1):
+        ctx.update({"index": idx, "script_line": line})
+        prompt = template.render(**ctx)
+        prompts.append(run_prompt(prompt))
+
+    return prompts
+

--- a/core/chains/timing_chain.py
+++ b/core/chains/timing_chain.py
@@ -1,1 +1,18 @@
-# Estimates scene timing based on token length or audio duration
+"""Timing estimation chain."""
+
+from typing import List, Dict
+
+from core.utils.tokenizer import count_tokens
+
+
+def estimate_timing(script: List[str], wpm: int = 120) -> List[Dict[str, float]]:
+    """Return a timing matrix using words-per-minute heuristic."""
+
+    timings = []
+    for line in script:
+        word_count = count_tokens(line)
+        seconds = max(1, (word_count / wpm) * 60)
+        timings.append({"line": line, "seconds": seconds})
+
+    return timings
+

--- a/core/services/bedrock_nova.py
+++ b/core/services/bedrock_nova.py
@@ -1,1 +1,8 @@
-# Wrapper to call Amazon Bedrock (Claude/Nova) for LLM tasks
+"""Tiny wrapper around a hypothetical Bedrock/Nova LLM API."""
+
+
+def run_prompt(prompt: str) -> str:
+    """Return a fake LLM result."""
+
+    return f"[LLM output for: {prompt[:30]}...]"
+

--- a/core/services/elevenlabs_api.py
+++ b/core/services/elevenlabs_api.py
@@ -1,1 +1,14 @@
-# Handles ElevenLabs voice generation and playback
+"""Simple ElevenLabs wrapper."""
+
+from pathlib import Path
+
+
+def synthesize_voice(text: str, config: dict) -> str:
+    """Pretend to create an MP3 file with ElevenLabs."""
+
+    out_dir = Path(config.get("output_dir", "output"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / "final_voiceover.mp3"
+    out_file.write_text("synthetic audio")
+    return str(out_file)
+

--- a/core/services/replicate_api.py
+++ b/core/services/replicate_api.py
@@ -1,1 +1,52 @@
-# Handles calls to Replicate video generation endpoints
+"""Video generation wrapper.
+
+This module optionally integrates with Replicate's API to render a video using
+the ``minimax/video-01`` model. If the ``replicate`` package is not available
+or the API call fails, a placeholder file is written so the rest of the
+pipeline can run without network access.
+"""
+
+from pathlib import Path
+from typing import List
+
+try:  # pragma: no cover - optional dependency
+    import replicate
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    replicate = None
+
+
+def render_video(storyboard: List[str], voice_path: str, config: dict) -> str:
+    """Render a video using Replicate if available.
+
+    Parameters
+    ----------
+    storyboard:
+        Ordered list of visual prompts for each scene.
+    voice_path:
+        Path to the previously generated voiceover file.
+    config:
+        Runtime configuration loaded from the project YAML.
+    """
+
+    out_dir = Path(config.get("output_dir", "output"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    video_file = out_dir / "final_video.mp4"
+
+    if replicate is None:
+        # Offline fallback for environments without the replicate package
+        video_file.write_text("synthetic video")
+        return str(video_file)
+
+    prompt = "\n".join(storyboard)
+    model_name = config.get("video_model", "minimax/video-01")
+
+    try:
+        output_url = replicate.run(model_name, input={"prompt": prompt})
+    except Exception:  # pragma: no cover - network errors ignored
+        video_file.write_text("synthetic video")
+        return str(video_file)
+
+    # If the model call succeeds, write the returned URI to a file for now
+    video_file.write_text(str(output_url))
+    return str(video_file)
+

--- a/core/services/s3_deployer.py
+++ b/core/services/s3_deployer.py
@@ -1,1 +1,9 @@
-# Deploys finished artifacts to S3 with rate limiting or TTL config
+"""Deployment helper for uploading assets to S3."""
+
+
+def deploy(path: str, config: dict) -> None:
+    """Pretend to deploy an artifact to S3."""
+
+    bucket = config.get("deployment", {}).get("s3_bucket", "demo")
+    print(f"Uploading {path} to s3://{bucket}/")
+

--- a/core/templates/visual_prompt.jinja
+++ b/core/templates/visual_prompt.jinja
@@ -1,1 +1,4 @@
-# Jinja template for generating visual prompts for each scene
+Create a cinematic shot description for scene {{ index }}.
+Use the metaphor world of {{ metaphor_world }} to illustrate the concept:
+"{{ script_line }}"
+Style should match {{ tone }}.

--- a/core/templates/vo_prompt.jinja
+++ b/core/templates/vo_prompt.jinja
@@ -1,1 +1,5 @@
-# Jinja template for generating voiceover lines from LLM
+You are an expert narrator speaking in the style of {{ narrator_style }}.
+Write one short line of voiceover for scene {{ index }} of {{ scene_count }}.
+Topic: {{ technical_topic }}.
+Metaphor world: {{ metaphor_world }}.
+Tone: {{ tone }}.

--- a/core/utils/tokenizer.py
+++ b/core/utils/tokenizer.py
@@ -1,1 +1,8 @@
-# Utility to count tokens or estimate speech time for narration
+"""Utility helpers for tokenization."""
+
+
+def count_tokens(text: str) -> int:
+    """Return a naive token count."""
+
+    return len(text.split())
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pyyaml
+jinja2
+boto3
+replicate


### PR DESCRIPTION
## Summary
- document full pipeline in `EXPLAINER.md`
- add installation instructions and new Makefile build command
- render script and storyboard using Jinja templates
- write all intermediate artifacts in the CLI
- standardize final file names for voice and video outputs

## Testing
- `pytest -q`
- `python -m cli.build_project projects/iam-possible/PROMPT_INPUTS.yaml` *(fails: ModuleNotFoundError: No module named 'jinja2')*

------
https://chatgpt.com/codex/tasks/task_e_68465279fbb8832abf69d23d00842ca2