### PR TITLE
Update to google/veo-3 video model

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ Copy `env.example` to `.env` and provide your credentials.
 - `ELEVENLABS_API_KEY` – used for voice synthesis.
 - `REPLICATE_API_TOKEN` – required for video generation with Replicate.
 
-By default the video step calls the `minimax/video-01` model on Replicate. If the `replicate` package is not installed or the API call fails, a placeholder file is created so you can test the rest of the pipeline offline. Text-to-text prompts use AWS Bedrock's Nova model, which reads credentials from your `~/.aws/credentials` file.
+By default the video step calls the `google/veo-3` model on Replicate. If the `replicate` package is not installed or the API call fails, a placeholder file is created so you can test the rest of the pipeline offline. Text-to-text prompts use AWS Bedrock's Nova model, which reads credentials from your `~/.aws/credentials` file.
 This repository contains lightweight stubs for each step so you can see how the
 pieces fit together before plugging in real API keys and logic.

--- a/core/services/replicate_api.py
+++ b/core/services/replicate_api.py
@@ -1,9 +1,9 @@
 """Video generation wrapper.
 
 This module optionally integrates with Replicate's API to render a video using
-the ``minimax/video-01`` model. If the ``replicate`` package is not available
-or the API call fails, a placeholder file is written so the rest of the
-pipeline can run without network access.
+the ``google/veo-3`` model. If the ``replicate`` package is not available or the
+API call fails, a placeholder file is written so the rest of the pipeline can
+run without network access.
 """
 
 from pathlib import Path
@@ -28,10 +28,15 @@ def render_video(prompts: List[str], voice_path: str, config: dict) -> str:
         return str(video_file)
 
     prompt = "\n".join(prompts)
-    model_name = config.get("video_model", "minimax/video-01")
+    model_name = config.get("video_model", "google/veo-3")
+
+    inputs = {"prompt": prompt}
+    seed = config.get("seed")
+    if seed is not None:
+        inputs["seed"] = seed
 
     try:
-        output_url = replicate.run(model_name, input={"prompt": prompt})
+        output_url = replicate.run(model_name, input=inputs)
     except Exception:  # pragma: no cover - network errors ignored
         video_file.write_text("synthetic video")
         return str(video_file)

--- a/projects/quick-demo/PROMPT_INPUTS.yaml
+++ b/projects/quick-demo/PROMPT_INPUTS.yaml
@@ -5,6 +5,6 @@ narrator_style: "Friendly"
 scene_count: 3
 tone: "Playful"
 voice_model: "ElevenLabs"
-video_model: "minimax/video-01"
+video_model: "google/veo-3"
 deployment:
   s3_bucket: "quick-demo"


### PR DESCRIPTION
## Summary
- default to the `google/veo-3` model for video rendering
- document the new model in README
- update sample config to use `google/veo-3`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ffb05238832a9238090c4b2eec48